### PR TITLE
documentation updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const type: isly.Type<DemoType> = isly.object({
 	fromServer: isly.boolean(true),
 
 	myTuple: isly.tuple(isly.string(), isly.number()),
-	myUnion: isly.union<DemoType["myUnion"]>(isly.string(), isly.number()),
+	myUnion: isly.union(isly.string(), isly.number()),
 	myArray: isly.array(isly.string(), { criteria: "minLength", value: 1 }),
 	myIntersection: isly.intersection(
 		isly.object<{ a: string }>({ a: isly.string() }),


### PR DESCRIPTION
while working with isly i found that when using the union type within an object one shouldnt use

myUnion: isly.union<DemoType["myUnion"]>(isly.string(), isly.number())

instead the correct way is:

myUnion: isly.union(isly.string(), isly.number())

I updated the README.md to reflect this.

